### PR TITLE
Add missing STATUS_BAR permission

### DIFF
--- a/AndroidManifest-common.xml
+++ b/AndroidManifest-common.xml
@@ -52,6 +52,7 @@
     <uses-permission android:name="android.permission.FORCE_STOP_PACKAGES" />
     <uses-permission android:name="android.permission.DEVICE_POWER" />
     <uses-permission android:name="android.permission.EXPAND_STATUS_BAR" />
+    <uses-permission android:name="android.permission.STATUS_BAR" />
 
     <!--
     Permissions required for read/write access to the workspace data. These permission name


### PR DESCRIPTION
java.lang.SecurityException: Permission Denial: setShelfHeight() from pid=2803, uid=10202 requires android.permission.STATUS_BAR
	at android.os.Parcel.createException(Parcel.java:2071)
	at android.os.Parcel.readException(Parcel.java:2039)
	at android.os.Parcel.readException(Parcel.java:1987)
	at android.view.IWindowManager$Stub$Proxy.setShelfHeight(IWindowManager.java:3775)
	at com.android.systemui.shared.system.WindowManagerWrapper.setShelfHeight(WindowManagerWrapper.java:148)
	at com.android.launcher3.uioverrides.RecentsUiFactory.lambda$static$0(RecentsUiFactory.java:62)
	at com.android.launcher3.uioverrides.-$$Lambda$RecentsUiFactory$kLTnyxU1D0UyyR3cYPdkjFJ_dRk.execute(Unknown Source:0)
	at com.android.launcher3.util.UiThreadHelper$UiCallbacks.handleMessage(UiThreadHelper.java:77)
	at android.os.Handler.dispatchMessage(Handler.java:103)
	at android.os.Looper.loop(Looper.java:214)
	at android.os.HandlerThread.run(HandlerThread.java:67)