### PR TITLE
SystemShortcuts: fix fc with InfoBottomSheet

### DIFF
--- a/src/com/android/launcher3/popup/SystemShortcut.java
+++ b/src/com/android/launcher3/popup/SystemShortcut.java
@@ -7,6 +7,7 @@ import android.app.ActivityOptions;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Rect;
+import android.view.InflateException;
 import android.view.View;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.ImageView;
@@ -137,19 +138,21 @@ public abstract class SystemShortcut<T extends BaseDraggingActivity> extends Ite
                     itemInfo);
         }
 
-        private InfoBottomSheet cbs;
-
         @Override
         public void onClick(View view) {
-            if (cbs == null) {
-                dismissTaskMenuView(mTarget);
-                Rect sourceBounds = mTarget.getViewBounds(view);
+            InfoBottomSheet cbs;
+            dismissTaskMenuView(mTarget);
+            Rect sourceBounds = mTarget.getViewBounds(view);
+            try {
                 cbs = (InfoBottomSheet) mTarget.getLayoutInflater().inflate(
                         R.layout.app_info_bottom_sheet,
                         mTarget.getDragLayer(),
                         false);
                 cbs.configureBottomSheet(sourceBounds, mTarget);
                 cbs.populateAndShow(mItemInfo);
+            } catch (InflateException e) {
+                new PackageManagerHelper(mTarget).startDetailsActivityForInfo(
+                        mItemInfo, sourceBounds, ActivityOptions.makeBasic().toBundle());
             }
             mTarget.getUserEventDispatcher().logActionOnControl(Action.Touch.TAP,
                     ControlType.APPINFO_TARGET, view);


### PR DESCRIPTION
After the addition of I34fe46944561723d3a47db92b3814e1deee80b5b,
when launchers without InfoBottomSheet support are used in place of crDroid
default launcher, a fc is observed when AppInfo is selected on task
shortcut menu in recents.

To fix that, add support for both AppInfo BottomSheet if supported and
the previous Settings info sheet

stacktrace: android.view.InflateException: Binary XML file line #2 in com.android.launcher3:layout/app_info_bottom_sheet: Binary XML file line #2 in com.android.launcher3:layout/app_info_bottom_sheet: Error inflating class com.android.launcher3.customization.InfoBottomSheet
Caused by: android.view.InflateException: Binary XML file line #2 in com.android.launcher3:layout/app_info_bottom_sheet: Error inflating class com.android.launcher3.customization.InfoBottomSheet
Caused by: java.lang.reflect.InvocationTargetException
	at java.lang.reflect.Constructor.newInstance0(Native Method)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:343)
	at android.view.LayoutInflater.createView(LayoutInflater.java:852)
	at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:1004)
	at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:959)
	at android.view.LayoutInflater.inflate(LayoutInflater.java:657)
	at android.view.LayoutInflater.inflate(LayoutInflater.java:532)
	at com.android.launcher3.popup.SystemShortcut$AppInfo.onClick(SystemShortcut.java:147)
	at android.view.View.performClick(View.java:7454)
	at android.view.View.performClickInternal(View.java:7431)
	at android.view.View.access$3600(View.java:810)
	at android.view.View$PerformClick.run(View.java:28311)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loop(Looper.java:223)
	at android.app.ActivityThread.main(ActivityThread.java:7660)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:594)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
Caused by: java.lang.ClassCastException: com.android.quickstep.RecentsActivity cannot be cast to com.android.launcher3.Launcher
	at com.android.launcher3.Launcher.getLauncher(Launcher.java:2762)
	at com.android.launcher3.views.AbstractSlideInView.<init>(AbstractSlideInView.java:77)
	at com.android.launcher3.widget.BaseWidgetSheet.<init>(BaseWidgetSheet.java:60)
	at com.android.launcher3.widget.WidgetsBottomSheet.<init>(WidgetsBottomSheet.java:73)
	at com.android.launcher3.customization.InfoBottomSheet.<init>(InfoBottomSheet.java:50)
	at com.android.launcher3.customization.InfoBottomSheet.<init>(InfoBottomSheet.java:46)
	... 19 more

Change-Id: I00c10b1f169c1403003593eba17e71b370716932
Signed-off-by: DennySPb <dennyspb@gmail.com>
Signed-off-by: Mrinal Ghosh <mg712702@gmail.com>