### PR TITLE
Launcher3: Make recents apps overview transparent

### DIFF
--- a/res/color-v31/overview_scrim.xml
+++ b/res/color-v31/overview_scrim.xml
@@ -14,5 +14,5 @@
      limitations under the License.
 -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:color="@android:color/system_neutral2_500" android:lStar="87" />
+  <item android:color="#80181c1f" />
 </selector>

--- a/res/color-v31/overview_scrim_dark.xml
+++ b/res/color-v31/overview_scrim_dark.xml
@@ -14,5 +14,5 @@
      limitations under the License.
 -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:color="@android:color/system_neutral1_500" android:lStar="35" />
+  <item android:color="#80181c1f" />
 </selector>


### PR DESCRIPTION
 This will add transparency for third party launchers

Signed-off-by: minarypenguin <alexfinhart@gmail.com>
Signed-off-by: DarkJoker360 <simoespo159@gmail.com>