### PR TITLE
Launcher3: Improve allapps header view

### DIFF
--- a/res/color-v31/overview_scrim.xml
+++ b/res/color-v31/overview_scrim.xml
@@ -14,5 +14,5 @@
      limitations under the License.
 -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:color="@android:color/system_neutral2_500" android:lStar="87" android:alpha="0.4" />
+  <item android:color="@android:color/system_neutral2_500" android:lStar="87" android:alpha="0.01" />
 </selector>

--- a/res/color-v31/overview_scrim_dark.xml
+++ b/res/color-v31/overview_scrim_dark.xml
@@ -14,5 +14,5 @@
      limitations under the License.
 -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:color="@android:color/system_neutral1_500" android:lStar="35" android:alpha="0.4" />
+  <item android:color="@android:color/system_neutral1_50" android:lStar="15" android:alpha="0.01" />
 </selector>

--- a/res/drawable/all_apps_search_hint.xml
+++ b/res/drawable/all_apps_search_hint.xml
@@ -16,5 +16,5 @@
 -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:color="@android:color/transparent" android:state_focused="true" />
-    <item android:color="?android:attr/textColorSecondary" android:alpha="?android:attr/disabledAlpha" />
+    <item android:color="?android:attr/textColorPrimaryInverse" android:alpha="?android:attr/disabledAlpha" />
 </selector>

--- a/res/drawable/ic_allapps_search.xml
+++ b/res/drawable/ic_allapps_search.xml
@@ -20,7 +20,7 @@
         android:height="24dp"
         android:viewportWidth="24"
         android:viewportHeight="24"
-        android:tint="?android:attr/textColorTertiary"
+        android:tint="?android:attr/textColorPrimaryInverse"
         android:autoMirrored="true">
     <path
         android:fillColor="#FF000000"

--- a/res/layout/all_apps_empty_search.xml
+++ b/res/layout/all_apps_empty_search.xml
@@ -24,7 +24,7 @@
     android:paddingLeft="16dp"
     android:paddingRight="16dp"
     android:fontFamily="@*android:string/config_bodyFontFamilyMedium"
-    android:textSize="14sp"
-    android:textColor="?android:attr/textColorTertiary"
+    android:textSize="16sp"
+    android:textColor="?android:attr/textColorPrimaryInverse"
     android:focusable="false" />
 

--- a/res/layout/search_container_all_apps.xml
+++ b/res/layout/search_container_all_apps.xml
@@ -36,6 +36,6 @@
     android:saveEnabled="false"
     android:scrollHorizontally="true"
     android:singleLine="true"
-    android:textColor="?android:attr/textColorSecondary"
+    android:textColor="?android:attr/textColorPrimaryInverse"
     android:textColorHint="@drawable/all_apps_search_hint"
     android:textSize="20sp" />

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -29,9 +29,9 @@
     </style>
 
     <style name="LauncherTheme" parent="@style/BaseLauncherTheme">
-        <item name="android:textColorSecondary">#DE000000</item>
-        <item name="allAppsScrimColor">?android:attr/colorBackgroundFloating</item>
-        <item name="allappsHeaderProtectionColor">@color/popup_color_tertiary_light</item>
+        <item name="android:textColorSecondary">?android:attr/colorAccent</item>
+        <item name="allAppsScrimColor">@color/overview_scrim</item>
+        <item name="allappsHeaderProtectionColor">?android:attr/colorAccent</item>
         <item name="allAppsNavBarScrimColor">#66FFFFFF</item>
         <item name="allAppsTheme">@style/AllAppsTheme</item>
         <item name="popupColorPrimary">@color/popup_color_primary_light</item>
@@ -98,8 +98,8 @@
         <item name="android:textColorHint">#A0FFFFFF</item>
         <item name="android:colorControlHighlight">#19FFFFFF</item>
         <item name="android:colorPrimary">#FF212121</item>
-        <item name="allAppsScrimColor">?android:attr/colorBackgroundFloating</item>
-        <item name="allappsHeaderProtectionColor">@color/popup_color_tertiary_dark</item>
+        <item name="allAppsScrimColor">@color/overview_scrim_dark</item>
+        <item name="allappsHeaderProtectionColor">?android:attr/colorAccent</item>
         <item name="allAppsNavBarScrimColor">#80000000</item>
         <item name="allAppsTheme">@style/AllAppsTheme.Dark</item>
         <item name="popupColorPrimary">@color/popup_color_primary_dark</item>


### PR DESCRIPTION
* Use and update overview_scrim for allAppsScrimColor
* HeaderProtectionColor switched to colorAccent
* Inverse color for Search Icon and Text
* Apps text label switched to colorAccent in light theme
* Fixed Alpha animation on swipe up
