### PR TITLE
Launcher3: Add kill action to app shortcuts popup

### DIFF
--- a/AndroidManifest-common.xml
+++ b/AndroidManifest-common.xml
@@ -55,6 +55,7 @@
     <uses-permission android:name="android.permission.MEDIA_CONTENT_CONTROL" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="lineageos.permission.WRITE_SETTINGS" />
+    <uses-permission android:name="android.permission.FORCE_STOP_PACKAGES" />
 
     <!-- Parallel space -->
     <uses-permission android:name="android.permission.MANAGE_PARALLEL_SPACES" />

--- a/quickstep/res/drawable/ic_kill_app.xml
+++ b/quickstep/res/drawable/ic_kill_app.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-     Copyright (C) 2019-2022 crDroid Android Project
+<!-- Copyright (C) 2018 The Android Open Source Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,11 +13,17 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<permissions>
-    <!-- Additional permissions on top of privapp_whitelist_com.android.launcher3.xml -->
-    <privapp-permissions package="com.android.launcher3">
-        <permission name="android.permission.SUSPEND_APPS"/>
-        <permission name="android.permission.INTERACT_ACROSS_USERS_FULL"/>
-        <permission name="android.permission.MEDIA_CONTENT_CONTROL"/>
-        <permission name="android.permission.FORCE_STOP_PACKAGES"/>
-    </privapp-permissions>
+
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:name="vector"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:name="path"
+        android:pathData="M 4.707 3.293 L 3.293 4.707 L 10.586 12 L 3.293 19.293 L 4.707 20.707 L 12 13.414 L 19.293 20.707 L 20.707 19.293 L 13.414 12 L 20.707 4.707 L 19.293 3.293 L 12 10.586 L 4.707 3.293 Z"
+        android:fillColor="#ff000000"
+        android:strokeWidth="1"/>
+</vector>

--- a/quickstep/src/com/android/quickstep/TaskOverlayFactory.java
+++ b/quickstep/src/com/android/quickstep/TaskOverlayFactory.java
@@ -121,6 +121,7 @@ public class TaskOverlayFactory implements ResourceBasedOverride {
     /** Note that these will be shown in order from top to bottom, if available for the task. */
     private static final TaskShortcutFactory[] MENU_OPTIONS = new TaskShortcutFactory[]{
             TaskShortcutFactory.APP_INFO,
+            TaskShortcutFactory.KILL_APP,
             TaskShortcutFactory.SPLIT_SELECT,
             TaskShortcutFactory.UNINSTALL,
             TaskShortcutFactory.PIN,

--- a/quickstep/src/com/android/quickstep/TaskShortcutFactory.java
+++ b/quickstep/src/com/android/quickstep/TaskShortcutFactory.java
@@ -22,7 +22,9 @@ import static com.android.launcher3.config.FeatureFlags.ENABLE_OVERVIEW_SELECTIO
 import static com.android.launcher3.logging.StatsLogManager.LauncherEvent.LAUNCHER_SYSTEM_SHORTCUT_FREE_FORM_TAP;
 
 import android.app.Activity;
+import android.app.ActivityManagerNative;
 import android.app.ActivityOptions;
+import android.app.IActivityManager;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.Rect;
@@ -31,10 +33,12 @@ import android.os.Looper;
 import android.os.RemoteException;
 import android.os.SystemProperties;
 import android.util.Log;
+import android.os.UserHandle;
 import android.view.View;
 import android.view.WindowInsets;
 import android.view.WindowManagerGlobal;
 import android.window.SplashScreen;
+import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 
@@ -409,4 +413,48 @@ public interface TaskShortcutFactory {
             return null;
         }
     };
+
+    TaskShortcutFactory KILL_APP = new TaskShortcutFactory() {
+        @Override
+        public List<SystemShortcut> getShortcuts(BaseDraggingActivity activity,
+                TaskIdAttributeContainer taskContainer) {
+                    String packageName = taskContainer.getItemInfo().getTargetComponent().getPackageName();
+                    return Collections.singletonList(new KillSystemShortcut(activity, taskContainer, packageName));
+        }
+    };
+
+    class KillSystemShortcut extends SystemShortcut {
+        private static final String TAG = "KillSystemShortcut";
+        private final TaskView mTaskView;
+        private final BaseDraggingActivity mActivity;
+        private final String mPackageName;
+
+        public KillSystemShortcut(BaseDraggingActivity activity,
+                TaskIdAttributeContainer taskContainer, String packageName) {
+            super(R.drawable.ic_kill_app, R.string.recent_task_option_kill_app,
+                    activity, taskContainer.getItemInfo(), taskContainer.getTaskView());
+            mTaskView = taskContainer.getTaskView();
+            mActivity = activity;
+            mPackageName = packageName;
+        }
+
+        @Override
+        public void onClick(View view) {
+            if (mPackageName != null) {
+                IActivityManager iam = ActivityManagerNative.getDefault();
+                Task task = mTaskView.getTask();
+                if (task != null) {
+                    try {
+                        iam.forceStopPackage(mPackageName, UserHandle.USER_CURRENT);
+                        Toast appKilled = Toast.makeText(mActivity, R.string.recents_app_killed,
+                            Toast.LENGTH_SHORT);
+                        appKilled.show();
+                        ((RecentsView)mActivity.getOverviewPanel())
+                              .dismissTask(mTaskView, true /* animate */, true /* removeTask */);
+                    } catch (RemoteException e) { }
+                }
+            }
+            dismissTaskMenuView(mActivity);
+        }
+    }
 }

--- a/res/values/cr_strings.xml
+++ b/res/values/cr_strings.xml
@@ -283,4 +283,8 @@
     <string name="icon_pack_default_label">Default</string>
     <string name="icon_pack_add">Install more</string>
     <string name="icon_pack_no_market">There\'s no available app store</string>
+   
+    <!-- Kill App recents action shortcut -->
+    <string name="recent_task_option_kill_app">Kill</string>
+    <string name="recents_app_killed">App killed</string>
 </resources>


### PR DESCRIPTION
Squashed:

Launcher3: Dismiss task from recents when killed

Change-Id: I25f37484a444346bf08e6960893892cc4bf25ada

Launcher3: Add FORCE_STOP_PACKAGES permission

Change-Id: I20dd0287c47269ccfdd02a8eae2a3da1de96e206

Launcher3: Update kill app button drawable

Change-Id: Iff78ae0528b8ed9c7b11952352e4b6d43507e233

[ghostrider-reborn: Add privapp permissions, adapt to Sv2] [jhonboy121]: adapt to A13
[MLZ94]: update shortcut logic after QPR1

Signed-off-by: Adithya R <gh0strider.2k18.reborn@gmail.com>
Signed-off-by: Pranav <npv12@iitbbs.ac.in>
Signed-off-by: jhonboy121 <alfredmathew05@gmail.com>
Signed-off-by: MLZ94 <zugutoroberto@gmail.com>
Change-Id: If6cce8cfb91a5efe1c99b795d58ed1fba4f706e4
Co-authored-by: Ali B <abittin@gmail.com>
Co-authored-by: Pranav Vashi <neobuddy89@gmail.com>
Co-authored-by: Alexandru Scurtu <sasha.scurtu@gmail.com>