### PR TITLE
Bring back memory info in overview

### DIFF
--- a/quickstep/res/layout/fallback_recents_activity.xml
+++ b/quickstep/res/layout/fallback_recents_activity.xml
@@ -51,5 +51,8 @@
             android:id="@+id/overview_actions_view"
             layout="@layout/overview_actions_container" />
 
+        <include
+            layout="@layout/meminfo" />
+
     </com.android.quickstep.fallback.RecentsDragLayer>
 </com.android.launcher3.LauncherRootView>

--- a/quickstep/res/layout/meminfo.xml
+++ b/quickstep/res/layout/meminfo.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.android.quickstep.views.MemInfoView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/meminfo"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:textColor="?android:attr/textColorPrimary"
+    android:textSize="12sp"
+    android:visibility="gone"/>

--- a/quickstep/res/layout/overview_panel.xml
+++ b/quickstep/res/layout/overview_panel.xml
@@ -29,4 +29,7 @@
         android:id="@+id/overview_actions_view"
         layout="@layout/overview_actions_container" />
 
+    <include
+        layout="@layout/meminfo" />
+
 </merge>

--- a/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
@@ -139,6 +139,7 @@ import com.android.quickstep.util.RemoteFadeOutAnimationListener;
 import com.android.quickstep.util.SplitSelectStateController;
 import com.android.quickstep.util.TISBindHelper;
 import com.android.quickstep.util.ViewCapture;
+import com.android.quickstep.views.MemInfoView;
 import com.android.quickstep.views.OverviewActionsView;
 import com.android.quickstep.views.RecentsView;
 import com.android.quickstep.views.TaskView;
@@ -172,6 +173,7 @@ public class QuickstepLauncher extends Launcher {
     private DepthController mDepthController;
     private QuickstepTransitionManager mAppTransitionManager;
     private OverviewActionsView mActionsView;
+    private MemInfoView mMemInfoView;
     private TISBindHelper mTISBindHelper;
     private @Nullable TaskbarManager mTaskbarManager;
     private @Nullable OverviewCommandHelper mOverviewCommandHelper;
@@ -214,13 +216,16 @@ public class QuickstepLauncher extends Launcher {
         super.setupViews();
 
         mActionsView = findViewById(R.id.overview_actions_view);
+        mMemInfoView = findViewById(R.id.meminfo);
         RecentsView overviewPanel = (RecentsView) getOverviewPanel();
         SplitSelectStateController controller =
                 new SplitSelectStateController(this, mHandler, getStateManager(),
                         getDepthController(), getStatsLogManager());
-        overviewPanel.init(mActionsView, controller);
+        overviewPanel.init(mActionsView, controller, mMemInfoView);
         mActionsView.updateDimension(getDeviceProfile(), overviewPanel.getLastComputedTaskSize());
+        mMemInfoView.setDp(getDeviceProfile());
         mActionsView.updateVerticalMargin(DisplayController.getNavigationMode(this));
+        mMemInfoView.updateVerticalMargin(DisplayController.getNavigationMode(this));
 
         mAppTransitionManager = new QuickstepTransitionManager(this);
         mAppTransitionManager.registerRemoteAnimations();
@@ -735,6 +740,10 @@ public class QuickstepLauncher extends Launcher {
         return (T) mActionsView;
     }
 
+    public MemInfoView getMemInfoView () {
+        return mMemInfoView;
+    }
+
     @Override
     protected void closeOpenViews(boolean animate) {
         super.closeOpenViews(animate);
@@ -911,6 +920,9 @@ public class QuickstepLauncher extends Launcher {
             getDragLayer().recreateControllers();
             if (mActionsView != null) {
                 mActionsView.updateVerticalMargin(info.navigationMode);
+            }
+            if (mMemInfoView != null) {
+                mMemInfoView.updateVerticalMargin(info.navigationMode);
             }
         }
     }

--- a/quickstep/src/com/android/launcher3/uioverrides/RecentsViewStateController.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/RecentsViewStateController.java
@@ -16,6 +16,7 @@
 package com.android.launcher3.uioverrides;
 
 import static com.android.launcher3.LauncherState.CLEAR_ALL_BUTTON;
+import static com.android.launcher3.LauncherState.MEMINFO;
 import static com.android.launcher3.LauncherState.OVERVIEW_ACTIONS;
 import static com.android.launcher3.LauncherState.OVERVIEW_SPLIT_SELECT;
 import static com.android.launcher3.anim.Interpolators.LINEAR;
@@ -46,6 +47,7 @@ import com.android.quickstep.util.AnimUtils;
 import com.android.quickstep.util.SplitAnimationTimings;
 import com.android.quickstep.views.ClearAllButton;
 import com.android.quickstep.views.LauncherRecentsView;
+import com.android.quickstep.views.MemInfoView;
 import com.android.quickstep.views.RecentsView;
 
 /**
@@ -157,6 +159,9 @@ public final class RecentsViewStateController extends
         propertySetter.setFloat(mLauncher.getActionsView().getVisibilityAlpha(),
                 MultiValueAlpha.VALUE, overviewButtonAlpha, config.getInterpolator(
                         ANIM_OVERVIEW_ACTIONS_FADE, LINEAR));
+        float memInfoAlpha = state.areElementsVisible(mLauncher, MEMINFO) ? 1 : 0;
+        propertySetter.setFloat(mLauncher.getMemInfoView(), MemInfoView.STATE_CTRL_ALPHA,
+                memInfoAlpha, LINEAR);
     }
 
     @Override

--- a/quickstep/src/com/android/launcher3/uioverrides/states/BackgroundAppState.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/states/BackgroundAppState.java
@@ -74,6 +74,7 @@ public class BackgroundAppState extends OverviewState {
     public int getVisibleElements(Launcher launcher) {
         return super.getVisibleElements(launcher)
                 & ~OVERVIEW_ACTIONS
+                & ~MEMINFO
                 & ~VERTICAL_SWIPE_INDICATOR;
     }
 

--- a/quickstep/src/com/android/launcher3/uioverrides/states/OverviewModalTaskState.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/states/OverviewModalTaskState.java
@@ -46,7 +46,7 @@ public class OverviewModalTaskState extends OverviewState {
 
     @Override
     public int getVisibleElements(Launcher launcher) {
-        return OVERVIEW_ACTIONS;
+        return OVERVIEW_ACTIONS | MEMINFO;
     }
 
     @Override

--- a/quickstep/src/com/android/launcher3/uioverrides/states/OverviewState.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/states/OverviewState.java
@@ -102,7 +102,7 @@ public class OverviewState extends LauncherState {
 
     @Override
     public int getVisibleElements(Launcher launcher) {
-        return OVERVIEW_ACTIONS;
+        return OVERVIEW_ACTIONS | MEMINFO;
     }
 
     @Override

--- a/quickstep/src/com/android/quickstep/RecentsActivity.java
+++ b/quickstep/src/com/android/quickstep/RecentsActivity.java
@@ -63,6 +63,7 @@ import com.android.launcher3.taskbar.FallbackTaskbarUIController;
 import com.android.launcher3.taskbar.TaskbarManager;
 import com.android.launcher3.util.ActivityOptionsWrapper;
 import com.android.launcher3.util.ActivityTracker;
+import com.android.launcher3.util.DisplayController;
 import com.android.launcher3.util.RunnableList;
 import com.android.launcher3.util.SystemUiController;
 import com.android.launcher3.util.Themes;
@@ -75,6 +76,7 @@ import com.android.quickstep.fallback.RecentsState;
 import com.android.quickstep.util.RecentsAtomicAnimationFactory;
 import com.android.quickstep.util.SplitSelectStateController;
 import com.android.quickstep.util.TISBindHelper;
+import com.android.quickstep.views.MemInfoView;
 import com.android.quickstep.views.OverviewActionsView;
 import com.android.quickstep.views.RecentsView;
 import com.android.quickstep.views.TaskView;
@@ -106,6 +108,7 @@ public final class RecentsActivity extends StatefulActivity<RecentsState> {
     private TISBindHelper mTISBindHelper;
     private @Nullable TaskbarManager mTaskbarManager;
     private @Nullable FallbackTaskbarUIController mTaskbarUIController;
+    private MemInfoView mMemInfoView;
 
     private StateManager<RecentsState> mStateManager;
 
@@ -127,13 +130,17 @@ public final class RecentsActivity extends StatefulActivity<RecentsState> {
         mScrimView = findViewById(R.id.scrim_view);
         mFallbackRecentsView = findViewById(R.id.overview_panel);
         mActionsView = findViewById(R.id.overview_actions_view);
+        mMemInfoView = findViewById(R.id.meminfo);
         SYSUI_PROGRESS.set(getRootView().getSysUiScrim(), 0f);
 
         SplitSelectStateController controller =
                 new SplitSelectStateController(this, mHandler, getStateManager(),
                         /* depthController */ null, getStatsLogManager());
         mDragLayer.recreateControllers();
-        mFallbackRecentsView.init(mActionsView, controller);
+        mFallbackRecentsView.init(mActionsView, controller, mMemInfoView);
+
+        mMemInfoView.setDp(mDeviceProfile);
+        mMemInfoView.updateVerticalMargin(DisplayController.getNavigationMode(this));
 
         mTISBindHelper = new TISBindHelper(this, this::onTISConnected);
     }
@@ -210,6 +217,10 @@ public final class RecentsActivity extends StatefulActivity<RecentsState> {
 
     public OverviewActionsView getActionsView() {
         return mActionsView;
+    }
+
+    public MemInfoView getMemInfoView() {
+        return mMemInfoView;
     }
 
     @Override

--- a/quickstep/src/com/android/quickstep/fallback/FallbackRecentsStateController.java
+++ b/quickstep/src/com/android/quickstep/fallback/FallbackRecentsStateController.java
@@ -48,6 +48,7 @@ import com.android.launcher3.states.StateAnimationConfig;
 import com.android.launcher3.util.MultiValueAlpha;
 import com.android.quickstep.RecentsActivity;
 import com.android.quickstep.views.ClearAllButton;
+import com.android.quickstep.views.MemInfoView;
 
 /**
  * State controller for fallback recents activity
@@ -96,6 +97,9 @@ public class FallbackRecentsStateController implements StateHandler<RecentsState
         float overviewButtonAlpha = state.hasOverviewActions() ? 1 : 0;
         setter.setFloat(mActivity.getActionsView().getVisibilityAlpha(),
                 MultiValueAlpha.VALUE, overviewButtonAlpha, LINEAR);
+        float memInfoAlpha = state.hasMemInfoView() ? 1 : 0;
+        setter.setFloat(mActivity.getMemInfoView(), MemInfoView.STATE_CTRL_ALPHA,
+                memInfoAlpha, LINEAR);
 
         float[] scaleAndOffset = state.getOverviewScaleAndOffset(mActivity);
         setter.setFloat(mRecentsView, RECENTS_SCALE_PROPERTY, scaleAndOffset[0],

--- a/quickstep/src/com/android/quickstep/fallback/FallbackRecentsView.java
+++ b/quickstep/src/com/android/quickstep/fallback/FallbackRecentsView.java
@@ -44,6 +44,7 @@ import com.android.quickstep.RotationTouchHelper;
 import com.android.quickstep.util.GroupTask;
 import com.android.quickstep.util.SplitSelectStateController;
 import com.android.quickstep.util.TaskViewSimulator;
+import com.android.quickstep.views.MemInfoView;
 import com.android.quickstep.views.OverviewActionsView;
 import com.android.quickstep.views.RecentsView;
 import com.android.quickstep.views.TaskView;
@@ -70,8 +71,9 @@ public class FallbackRecentsView extends RecentsView<RecentsActivity, RecentsSta
     }
 
     @Override
-    public void init(OverviewActionsView actionsView, SplitSelectStateController splitController) {
-        super.init(actionsView, splitController);
+    public void init(OverviewActionsView actionsView, SplitSelectStateController splitController,
+                        MemInfoView memInfoView) {
+        super.init(actionsView, splitController, memInfoView);
         setOverviewStateEnabled(true);
         setOverlayEnabled(true);
     }

--- a/quickstep/src/com/android/quickstep/fallback/RecentsState.java
+++ b/quickstep/src/com/android/quickstep/fallback/RecentsState.java
@@ -42,13 +42,15 @@ public class RecentsState implements BaseState<RecentsState> {
     private static final int FLAG_LIVE_TILE = BaseState.getFlag(6);
     private static final int FLAG_OVERVIEW_UI = BaseState.getFlag(7);
     private static final int FLAG_TASK_THUMBNAIL_SPLASH = BaseState.getFlag(8);
+    private static final int FLAG_MEMINFO = BaseState.getFlag(8);
 
     public static final RecentsState DEFAULT = new RecentsState(0,
             FLAG_DISABLE_RESTORE | FLAG_CLEAR_ALL_BUTTON | FLAG_OVERVIEW_ACTIONS | FLAG_SHOW_AS_GRID
-                    | FLAG_SCRIM | FLAG_LIVE_TILE | FLAG_OVERVIEW_UI);
+                    | FLAG_SCRIM | FLAG_LIVE_TILE | FLAG_OVERVIEW_UI | FLAG_MEMINFO);
     public static final RecentsState MODAL_TASK = new ModalState(1,
             FLAG_DISABLE_RESTORE | FLAG_CLEAR_ALL_BUTTON | FLAG_OVERVIEW_ACTIONS | FLAG_MODAL
-                    | FLAG_SHOW_AS_GRID | FLAG_SCRIM | FLAG_LIVE_TILE | FLAG_OVERVIEW_UI);
+                    | FLAG_SHOW_AS_GRID | FLAG_SCRIM | FLAG_LIVE_TILE | FLAG_OVERVIEW_UI
+                     | FLAG_MEMINFO);
     public static final RecentsState BACKGROUND_APP = new BackgroundAppState(2,
             FLAG_DISABLE_RESTORE | FLAG_NON_INTERACTIVE | FLAG_FULL_SCREEN | FLAG_OVERVIEW_UI
                     | FLAG_TASK_THUMBNAIL_SPLASH);
@@ -113,6 +115,13 @@ public class RecentsState implements BaseState<RecentsState> {
      */
     public boolean hasOverviewActions() {
         return hasFlag(FLAG_OVERVIEW_ACTIONS);
+    }
+
+    /**
+     * For this state, whether mem info view should be shown.
+     */
+    public boolean hasMemInfoView() {
+        return hasFlag(FLAG_MEMINFO);
     }
 
     /**

--- a/quickstep/src/com/android/quickstep/views/LauncherRecentsView.java
+++ b/quickstep/src/com/android/quickstep/views/LauncherRecentsView.java
@@ -65,8 +65,9 @@ public class LauncherRecentsView extends RecentsView<QuickstepLauncher, Launcher
 
     @Override
     public void init(OverviewActionsView actionsView,
-            SplitSelectStateController splitPlaceholderView) {
-        super.init(actionsView, splitPlaceholderView);
+            SplitSelectStateController splitPlaceholderView,
+            MemInfoView memInfoView) {
+        super.init(actionsView, splitPlaceholderView, memInfoView);
         setContentAlpha(0);
     }
 

--- a/quickstep/src/com/android/quickstep/views/MemInfoView.java
+++ b/quickstep/src/com/android/quickstep/views/MemInfoView.java
@@ -34,6 +34,7 @@ import com.android.launcher3.DeviceProfile;
 import com.android.launcher3.util.MultiValueAlpha;
 import com.android.launcher3.util.NavigationMode;
 import com.android.launcher3.R;
+import com.android.launcher3.Utilities;
 
 import java.lang.Runnable;
 import java.math.BigDecimal;
@@ -87,6 +88,11 @@ public class MemInfoView extends TextView {
      * influenced by more factors, leading to unstable behavior. */
     @Override
     public void setVisibility(int visibility) {
+        if (visibility == VISIBLE) {
+            boolean showMeminfo = Utilities.isShowMeminfo(getContext());
+            if (!showMeminfo) visibility = GONE;
+        }
+
         super.setVisibility(visibility);
 
         if (visibility == VISIBLE)

--- a/quickstep/src/com/android/quickstep/views/MemInfoView.java
+++ b/quickstep/src/com/android/quickstep/views/MemInfoView.java
@@ -70,6 +70,7 @@ public class MemInfoView extends TextView {
     private MemInfoWorker mWorker;
 
     private String mMemInfoText;
+    private boolean mMemInfoBelowActions;
 
     public MemInfoView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -81,6 +82,8 @@ public class MemInfoView extends TextView {
         mWorker = new MemInfoWorker();
 
         mMemInfoText = context.getResources().getString(R.string.meminfo_text);
+        mMemInfoBelowActions =
+            context.getResources().getBoolean(R.bool.config_placeMemInfoBelowActions);
     }
 
     /* Hijack this method to detect visibility rather than
@@ -126,7 +129,8 @@ public class MemInfoView extends TextView {
         topMargin = mDp.memInfoMarginTop;
 
         lp.setMargins(lp.leftMargin, topMargin, lp.rightMargin, bottomMargin);
-        lp.gravity = Gravity.CENTER_HORIZONTAL | Gravity.TOP;
+        lp.gravity = Gravity.CENTER_HORIZONTAL |
+            (mMemInfoBelowActions ? Gravity.BOTTOM : Gravity.TOP);
     }
 
     private String unitConvert(long valueMiB, boolean alignToGB) {

--- a/quickstep/src/com/android/quickstep/views/MemInfoView.java
+++ b/quickstep/src/com/android/quickstep/views/MemInfoView.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2022 Project Kaleidoscope
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.quickstep.views;
+
+import static com.android.launcher3.util.NavigationMode.THREE_BUTTONS;
+
+import android.app.ActivityManager;
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.AttributeSet;
+import android.util.FloatProperty;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.FrameLayout.LayoutParams;
+import android.widget.TextView;
+
+import com.android.launcher3.anim.AlphaUpdateListener;
+import com.android.launcher3.DeviceProfile;
+import com.android.launcher3.util.MultiValueAlpha;
+import com.android.launcher3.util.NavigationMode;
+import com.android.launcher3.R;
+
+import java.lang.Runnable;
+import java.math.BigDecimal;
+
+public class MemInfoView extends TextView {
+
+    // When to show GB instead of MB
+    private static final int UNIT_CONVERT_THRESHOLD = 1024; /* MiB */
+
+    private static final BigDecimal GB2MB = new BigDecimal(1024);
+
+    private static final int ALPHA_STATE_CTRL = 0;
+    public static final int ALPHA_FS_PROGRESS = 1;
+
+    public static final FloatProperty<MemInfoView> STATE_CTRL_ALPHA =
+            new FloatProperty<MemInfoView>("state control alpha") {
+                @Override
+                public Float get(MemInfoView view) {
+                    return view.getAlpha(ALPHA_STATE_CTRL);
+                }
+
+                @Override
+                public void setValue(MemInfoView view, float v) {
+                    view.setAlpha(ALPHA_STATE_CTRL, v);
+                }
+            };
+
+    private DeviceProfile mDp;
+    private MultiValueAlpha mAlpha;
+    private ActivityManager mActivityManager;
+
+    private Handler mHandler;
+    private MemInfoWorker mWorker;
+
+    private String mMemInfoText;
+
+    public MemInfoView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+        mAlpha = new MultiValueAlpha(this, 2);
+        mAlpha.setUpdateVisibility(true);
+        mActivityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        mHandler = new Handler(Looper.getMainLooper());
+        mWorker = new MemInfoWorker();
+
+        mMemInfoText = context.getResources().getString(R.string.meminfo_text);
+    }
+
+    /* Hijack this method to detect visibility rather than
+     * onVisibilityChanged() because the the latter one can be
+     * influenced by more factors, leading to unstable behavior. */
+    @Override
+    public void setVisibility(int visibility) {
+        super.setVisibility(visibility);
+
+        if (visibility == VISIBLE)
+            mHandler.post(mWorker);
+        else
+            mHandler.removeCallbacks(mWorker);
+    }
+
+    public void setDp(DeviceProfile dp) {
+        mDp = dp;
+    }
+
+    public void setAlpha(int alphaType, float alpha) {
+        mAlpha.getProperty(alphaType).setValue(alpha);
+    }
+
+    public float getAlpha(int alphaType) {
+        return mAlpha.getProperty(alphaType).getValue();
+    }
+
+    public void updateVerticalMargin(NavigationMode mode) {
+        LayoutParams lp = (LayoutParams)getLayoutParams();
+        int bottomMargin;
+
+        if (mode == THREE_BUTTONS)
+            bottomMargin = mDp.memInfoMarginThreeButtonPx;
+        else
+            bottomMargin = mDp.memInfoMarginGesturePx;
+
+        lp.setMargins(lp.leftMargin, lp.topMargin, lp.rightMargin, bottomMargin);
+        lp.gravity = Gravity.CENTER_HORIZONTAL | Gravity.BOTTOM;
+    }
+
+    private String unitConvert(long valueMiB, boolean alignToGB) {
+        BigDecimal rawVal = new BigDecimal(valueMiB);
+
+        if (alignToGB)
+            return rawVal.divide(GB2MB, 0, BigDecimal.ROUND_UP) + " GB";
+
+        if (valueMiB > UNIT_CONVERT_THRESHOLD)
+            return rawVal.divide(GB2MB, 1, BigDecimal.ROUND_HALF_UP) + " GB";
+        else
+            return rawVal + " MB";
+    }
+
+    private void updateMemInfoText(long availMemMiB, long totalMemMiB) {
+        String text = String.format(mMemInfoText,
+            unitConvert(availMemMiB, false), unitConvert(totalMemMiB, true));
+        setText(text);
+    }
+
+    private class MemInfoWorker implements Runnable {
+        @Override
+        public void run() {
+            ActivityManager.MemoryInfo memInfo = new ActivityManager.MemoryInfo();
+            mActivityManager.getMemoryInfo(memInfo);
+            long availMemMiB = memInfo.availMem / (1024 * 1024);
+            long totalMemMiB = memInfo.totalMem / (1024 * 1024);
+            updateMemInfoText(availMemMiB, totalMemMiB);
+
+            mHandler.postDelayed(this, 1000);
+        }
+    }
+}

--- a/quickstep/src/com/android/quickstep/views/MemInfoView.java
+++ b/quickstep/src/com/android/quickstep/views/MemInfoView.java
@@ -110,14 +110,17 @@ public class MemInfoView extends TextView {
     public void updateVerticalMargin(NavigationMode mode) {
         LayoutParams lp = (LayoutParams)getLayoutParams();
         int bottomMargin;
+        int topMargin;
 
         if (mode == THREE_BUTTONS)
             bottomMargin = mDp.memInfoMarginThreeButtonPx;
         else
             bottomMargin = mDp.memInfoMarginGesturePx;
 
-        lp.setMargins(lp.leftMargin, lp.topMargin, lp.rightMargin, bottomMargin);
-        lp.gravity = Gravity.CENTER_HORIZONTAL | Gravity.BOTTOM;
+        topMargin = mDp.memInfoMarginTop;
+
+        lp.setMargins(lp.leftMargin, topMargin, lp.rightMargin, bottomMargin);
+        lp.gravity = Gravity.CENTER_HORIZONTAL | Gravity.TOP;
     }
 
     private String unitConvert(long valueMiB, boolean alignToGB) {

--- a/quickstep/src/com/android/quickstep/views/RecentsView.java
+++ b/quickstep/src/com/android/quickstep/views/RecentsView.java
@@ -696,6 +696,7 @@ public abstract class RecentsView<ACTIVITY_TYPE extends StatefulActivity<STATE_T
     private OverviewActionsView mActionsView;
     private ObjectAnimator mActionsViewAlphaAnimator;
     private float mActionsViewAlphaAnimatorFinalValue;
+    private MemInfoView mMemInfoView;
 
     private MultiWindowModeChangedListener mMultiWindowModeChangedListener =
             new MultiWindowModeChangedListener() {
@@ -913,10 +914,12 @@ public abstract class RecentsView<ACTIVITY_TYPE extends StatefulActivity<STATE_T
         updateTaskStackListenerState();
     }
 
-    public void init(OverviewActionsView actionsView, SplitSelectStateController splitController) {
+    public void init(OverviewActionsView actionsView, SplitSelectStateController splitController,
+                        MemInfoView memInfoView) {
         mActionsView = actionsView;
         mActionsView.updateHiddenFlags(HIDDEN_NO_TASKS, getTaskViewCount() == 0);
         mSplitSelectStateController = splitController;
+        mMemInfoView = memInfoView;
     }
 
     public SplitSelectStateController getSplitSelectController() {
@@ -1672,8 +1675,9 @@ public abstract class RecentsView<ACTIVITY_TYPE extends StatefulActivity<STATE_T
         mClearAllButton.setFullscreenProgress(fullscreenProgress);
 
         // Fade out the actions view quickly (0.1 range)
-        mActionsView.getFullscreenAlpha().setValue(
-                mapToRange(fullscreenProgress, 0, 0.1f, 1f, 0f, LINEAR));
+        float alpha = mapToRange(fullscreenProgress, 0, 0.1f, 1f, 0f, LINEAR);
+        mActionsView.getFullscreenAlpha().setValue(alpha);
+        mMemInfoView.setAlpha(MemInfoView.ALPHA_FS_PROGRESS, alpha);
     }
 
     private void updateTaskStackListenerState() {

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -208,4 +208,7 @@
 
     <string name="floating_task_package" translatable="false"></string>
     <string name="floating_task_action" translatable="false"></string>
+
+    <!-- Whether to place memory info below action buttons. -->
+    <bool name="config_placeMemInfoBelowActions">false</bool>
 </resources>

--- a/res/values/cr_dimens.xml
+++ b/res/values/cr_dimens.xml
@@ -22,4 +22,8 @@
 
     <!-- Overview scrolling scale animation -->
     <dimen name="overview_scroll_scale">0.9</dimen>
+
+     <!-- Meminfo in overview -->
+    <dimen name="meminfo_bottom_margin_gesture">15dp</dimen>
+    <dimen name="meminfo_bottom_margin_three_button">15dp</dimen>
 </resources>

--- a/res/values/cr_dimens.xml
+++ b/res/values/cr_dimens.xml
@@ -26,4 +26,5 @@
      <!-- Meminfo in overview -->
     <dimen name="meminfo_bottom_margin_gesture">15dp</dimen>
     <dimen name="meminfo_bottom_margin_three_button">15dp</dimen>
+    <dimen name="meminfo_top_margin">18dp</dimen>
 </resources>

--- a/res/values/cr_strings.xml
+++ b/res/values/cr_strings.xml
@@ -286,4 +286,5 @@
 
     <!-- Memory info -->
     <string name="meminfo_text">%1$s Available | %2$s Total</string>
+    <string name="recents_meminfo_title">Memory info</string>
 </resources>

--- a/res/values/cr_strings.xml
+++ b/res/values/cr_strings.xml
@@ -283,4 +283,7 @@
     <string name="icon_pack_default_label">Default</string>
     <string name="icon_pack_add">Install more</string>
     <string name="icon_pack_no_market">There\'s no available app store</string>
+
+    <!-- Memory info -->
+    <string name="meminfo_text">%1$s Available | %2$s Total</string>
 </resources>

--- a/res/xml/launcher_recents_preferences.xml
+++ b/res/xml/launcher_recents_preferences.xml
@@ -22,6 +22,12 @@
     <PreferenceCategory
         android:title="@string/general_category_title">
 
+        <SwitchPreference
+            android:key="pref_recents_meminfo"
+            android:title="@string/recents_meminfo_title"
+            android:defaultValue="false"
+            android:persistent="true" />
+
         <com.android.launcher3.settings.preferences.CustomSeekBarPreference
             android:key="pref_recents_opacity"
             android:title="@string/background_opacity_title"

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -257,6 +257,10 @@ public class DeviceProfile {
     // DragController
     public int flingToDeleteThresholdVelocity;
 
+    // Meminfo in overview
+    public int memInfoMarginGesturePx;
+    public int memInfoMarginThreeButtonPx;
+
     /** TODO: Once we fully migrate to staged split, remove "isMultiWindowMode" */
     DeviceProfile(Context context, InvariantDeviceProfile inv, Info info, WindowBounds windowBounds,
             SparseArray<DotRenderer> dotRendererCache, boolean isMultiWindowMode,
@@ -473,6 +477,11 @@ public class DeviceProfile {
         overviewActionsHeight = res.getDimensionPixelSize(R.dimen.overview_actions_height);
         overviewRowSpacing = res.getDimensionPixelSize(R.dimen.overview_grid_row_spacing);
         overviewGridSideMargin = res.getDimensionPixelSize(R.dimen.overview_grid_side_margin);
+
+        memInfoMarginGesturePx = res.getDimensionPixelSize(
+                R.dimen.meminfo_bottom_margin_gesture);
+        memInfoMarginThreeButtonPx = res.getDimensionPixelSize(
+                R.dimen.meminfo_bottom_margin_three_button);
 
         // Calculate all of the remaining variables.
         extraSpace = updateAvailableDimensions(res);

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -260,6 +260,7 @@ public class DeviceProfile {
     // Meminfo in overview
     public int memInfoMarginGesturePx;
     public int memInfoMarginThreeButtonPx;
+    public int memInfoMarginTop;
 
     /** TODO: Once we fully migrate to staged split, remove "isMultiWindowMode" */
     DeviceProfile(Context context, InvariantDeviceProfile inv, Info info, WindowBounds windowBounds,
@@ -482,6 +483,8 @@ public class DeviceProfile {
                 R.dimen.meminfo_bottom_margin_gesture);
         memInfoMarginThreeButtonPx = res.getDimensionPixelSize(
                 R.dimen.meminfo_bottom_margin_three_button);
+        memInfoMarginTop = res.getDimensionPixelSize(
+                R.dimen.meminfo_top_margin);
 
         // Calculate all of the remaining variables.
         extraSpace = updateAvailableDimensions(res);

--- a/src/com/android/launcher3/LauncherState.java
+++ b/src/com/android/launcher3/LauncherState.java
@@ -61,6 +61,7 @@ public abstract class LauncherState implements BaseState<LauncherState> {
     public static final int CLEAR_ALL_BUTTON = 1 << 4;
     public static final int WORKSPACE_PAGE_INDICATOR = 1 << 5;
     public static final int SPLIT_PLACHOLDER_VIEW = 1 << 6;
+    public static final int MEMINFO = 1 << 7;
 
     // Flag indicating workspace has multiple pages visible.
     public static final int FLAG_MULTI_PAGE = BaseState.getFlag(0);

--- a/src/com/android/launcher3/Utilities.java
+++ b/src/com/android/launcher3/Utilities.java
@@ -191,6 +191,7 @@ public final class Utilities {
     public static final String KEY_SHOW_QUICKSPACE_WEATHER = "pref_quickspace_weather";
     public static final String KEY_RECENTS_OPACITY = "pref_recents_opacity";
     public static final String KEY_APP_DRAWER_OPACITY = "pref_app_drawer_opacity";
+    public static final String KEY_RECENTS_MEMINFO = "pref_recents_meminfo";
 
     /**
      * Returns true if theme is dark.
@@ -1132,4 +1133,9 @@ public final class Utilities {
         SharedPreferences prefs = getPrefs(context.getApplicationContext());
         return prefs.getInt(KEY_APP_DRAWER_OPACITY, 80);
     }
+
+    public static boolean isShowMeminfo(Context context) {
+        SharedPreferences prefs = getPrefs(context.getApplicationContext());
+        return prefs.getBoolean(KEY_RECENTS_MEMINFO, false);
+   }
 }


### PR DESCRIPTION
Backported from A12L with little adaptations for newer A13 codebase.
Still keeping the mem info at the top, but on my 5" screen it overlaps the app icon. I had this issue even on A12L, so now I decided to add overlay config to allow it to be placed below action buttons, and now it's perfect. On bigger screens it should be fine, but I'm not sure as I can't verify this myself, so test assiduously with nav bar, gestures mode, three buttons mode, rotated screen etc.