### PR TITLE
Launcher3: Add an option to launch Google Music Search instead of Google Assistant

### DIFF
--- a/quickstep/res/drawable/ic_screenshot_recents.xml
+++ b/quickstep/res/drawable/ic_screenshot_recents.xml
@@ -1,0 +1,32 @@
+<!-- Copyright (C) 2020 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M5.8334,1.666H8.3334V3.3327H5.8334V6.666H4.1667V3.3327C4.1667,2.4122 4.9129,1.666 5.8334,1.666Z"
+      android:fillColor="?android:attr/colorAccent" />
+  <path
+      android:pathData="M4.1667,13.3327V16.666C4.1667,17.5865 4.9129,18.3327 5.8334,18.3327H8.3334V16.666H5.8334V13.3327H4.1667Z"
+      android:fillColor="?android:attr/colorAccent" />
+  <path
+      android:pathData="M14.1667,13.3327V16.666H11.6667V18.3327H14.1667C15.0872,18.3327 15.8334,17.5865 15.8334,16.666V13.3327H14.1667Z"
+      android:fillColor="?android:attr/colorAccent" />
+  <path
+      android:pathData="M15.8334,6.666V3.3327C15.8334,2.4122 15.0872,1.666 14.1667,1.666H11.6667V3.3327H14.1667V6.666H15.8334Z"
+      android:fillColor="?android:attr/colorAccent" />
+</vector>

--- a/quickstep/res/layout/overview_actions_container.xml
+++ b/quickstep/res/layout/overview_actions_container.xml
@@ -37,7 +37,7 @@
             style="@style/OverviewActionButton"
             android:layout_width="60dp"
             android:layout_height="36dp"
-            android:foreground="@drawable/ic_screenshot"
+            android:foreground="@drawable/ic_screenshot_recents"
             android:foregroundGravity="center" />
 
         <Space

--- a/quickstep/res/layout/overview_actions_container.xml
+++ b/quickstep/res/layout/overview_actions_container.xml
@@ -24,6 +24,8 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/overview_actions_height"
         android:layout_gravity="bottom|center_horizontal"
+        android:layout_marginLeft="30dp"
+        android:layout_marginRight="30dp"
         android:orientation="horizontal">
 
         <Space


### PR DESCRIPTION
Many users, me included, don't use Google Assistant. We add an option in the settings to launch Google Music Search instead on pressing Mic icon. Keep this option disabled by default. User enables if prefer.

Demo video https://drive.google.com/file/d/1iGiofk32p5jr0kYcNE_c4vf_pZF5o6-G/view?usp=share_link