### PR TITLE
Allow widgets to have 1 grid row as minimum size

### DIFF
--- a/src/com/android/launcher3/widget/LauncherAppWidgetProviderInfo.java
+++ b/src/com/android/launcher3/widget/LauncherAppWidgetProviderInfo.java
@@ -123,7 +123,7 @@ public class LauncherAppWidgetProviderInfo extends AppWidgetProviderInfo
             minSpanX = Math.max(minSpanX,
                     getSpanX(localPadding, minResizeWidth, dp.cellLayoutBorderSpacePx.x,
                             cellSize.x));
-            minSpanY = Math.max(minSpanY,
+            minSpanY = Math.min(minSpanY,
                     getSpanY(localPadding, minResizeHeight, dp.cellLayoutBorderSpacePx.y,
                             cellSize.y));
 


### PR DESCRIPTION
This comes from one of my favorite 3rd party launchers, NeoLauncher (Formerly OmegaLauncher, originally a fork of Lawnchair in Android 10/11 days I think?):
https://github.com/NeoApplications/Neo-Launcher/commit/1d160a82c6ea4e3e0c8a89b7e566dbb7c7036ad2

The problem:
- With Android 12, Google made all UI elements look too big like a preschool toy on my phone with 6"+ screen
- Try to change TARGET_SCREEN_DENSITY (or just `setprop ro.sf.lcd_density`) and it looks better, but if I change home screen grid from 5x5 to 5x6 or more, then widgets now force themselves to be 2 grid rows tall, instead of 1.

This fixes it and allows launcher to always resize widgets down to 1 grid row as minimum height, regardless of grid size (while still respecting default widget size).

Tests: Cherry-picked, resolved, compiled, flashed, added new widgets & resized existing, now they can be set to 1 row height.

Before (5x6 grid):
![Screenshot_20230128-175414_crDroid Home](https://user-images.githubusercontent.com/34873300/215300847-bcb8dba8-3d00-4917-a955-d49afb3c3116.png)
(impossible to resize to 1 row height, it always jumps back to 2)

After (5x6 grid):
![Screenshot_20230128-181154_crDroid Home](https://user-images.githubusercontent.com/34873300/215300889-63f2340d-426b-407b-aaf5-62422700c864.png)

(also fixup no newline at end of file)