### PR TITLE
Launcher3: Allow widgets to have 1 row as minimum size

### DIFF
--- a/src/com/android/launcher3/widget/LauncherAppWidgetProviderInfo.java
+++ b/src/com/android/launcher3/widget/LauncherAppWidgetProviderInfo.java
@@ -113,7 +113,7 @@ public class LauncherAppWidgetProviderInfo extends AppWidgetProviderInfo
             minSpanX = Math.max(minSpanX,
                     getSpanX(widgetPadding, minResizeWidth, dp.cellLayoutBorderSpacePx.x,
                             cellSize.x));
-            minSpanY = Math.max(minSpanY,
+            minSpanY = Math.min(minSpanY,
                     getSpanY(widgetPadding, minResizeHeight, dp.cellLayoutBorderSpacePx.y,
                             cellSize.y));
 


### PR DESCRIPTION
Most higher-density home screen grids compress spacing vertically.
Some widgets fit in 1 vertical grid row at 5x5, but Android will not let them resize to 1 grid row when you change grid density to 5x6 or higher, due to "desired" height is calculated.

Change the logic to always allow vertical resizing to 1 grid row; since users should be allowed to decide if they like how the widget looks for themselves, rather than Android limiting things programmatically.

(also clean up lack of newline at EOF)