### PR TITLE
Launcher3: Quickstep: Don't call doScrollScale() if device is a tablet.

### DIFF
--- a/quickstep/src/com/android/quickstep/views/RecentsView.java
+++ b/quickstep/src/com/android/quickstep/views/RecentsView.java
@@ -4398,7 +4398,7 @@ public abstract class RecentsView<ACTIVITY_TYPE extends StatefulActivity<STATE_T
                         .setScroll(getScrollOffset()));
         setImportantForAccessibility(isModal() ? IMPORTANT_FOR_ACCESSIBILITY_NO
                 : IMPORTANT_FOR_ACCESSIBILITY_AUTO);
-        doScrollScale();
+        if(!mActivity.getDeviceProfile().isTablet) doScrollScale();
     }
 
     private void updatePivots() {
@@ -6026,7 +6026,7 @@ public abstract class RecentsView<ACTIVITY_TYPE extends StatefulActivity<STATE_T
     protected void onScrollChanged(int l, int t, int oldl, int oldt) {
         super.onScrollChanged(l, t, oldl, oldt);
         dispatchScrollChanged();
-        doScrollScale();
+        if(!mActivity.getDeviceProfile().isTablet) doScrollScale();
     }
 
     private void doScrollScale() {


### PR DESCRIPTION
* Calling doScrollScale() on a tablet causes the app to become "small" and then expands to fit the screen when scrolling
* Bug has been reproduced on nabu(Xiaomi Pad 5), pipa(Xiaomi Pad 6) and gta4xl(Samsung Tab S6 Lite)
* Original patch was by kfkcome(https://github.com/Kfkcome/android_packages_apps_Launcher3/commit/69c0319666cbb84e34a65cb770c4c4188253d50c)

If you want video of the bug(I cant really explain it well), please message me on telegram(@pugzarecute)