### PR TITLE
Fix race condition when performing settings toggle restart

### DIFF
--- a/src/com/android/launcher3/Utilities.java
+++ b/src/com/android/launcher3/Utilities.java
@@ -147,7 +147,7 @@ public final class Utilities {
     public static final boolean ATLEAST_V = Build.VERSION.SDK_INT
             >= VERSION_CODES.VANILLA_ICE_CREAM;
 
-    private static final long WAIT_BEFORE_RESTART = 250;
+    private static final long WAIT_BEFORE_RESTART = 1250;
 
     /**
      * Set on a motion event dispatched from the nav bar. See {@link MotionEvent#setEdgeFlags(int)}.
@@ -993,11 +993,10 @@ public final class Utilities {
 
     public static void restart(final Context context) {
         MODEL_EXECUTOR.execute(() -> {
-            try {
-                Thread.sleep(WAIT_BEFORE_RESTART);
-            } catch (Exception ignored) {
-            }
-            android.os.Process.killProcess(android.os.Process.myPid());
+            final Handler handler = new Handler(Looper.getMainLooper());
+            handler.postDelayed(() -> {
+                android.os.Process.killProcess(android.os.Process.myPid());
+            }, WAIT_BEFORE_RESTART);
         });
     }
 


### PR DESCRIPTION
* we should avoid using thread sleep and restarting the launcher when its on recents view, otherwise a severe lag will occur during overview swipe up due to depth controller performing blur animation and restart method of the launcher, which creates a glitch of two launcher homescreens if the ui doesnt lag during recents blur animation